### PR TITLE
use should-not-typecheck to make library installable

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,24 +28,15 @@ dependencies:
 library:
   source-dirs: src
 
-executables:
-  servant-validate-sample:
-    main:                servant-validate-sample.hs
-    source-dirs:         app
+tests:
+  servant-validate-test:
+    main:                Spec.hs
+    source-dirs:         test
     ghc-options:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
     - servant-validate
-
-# tests:
-#   servant-validate-test:
-#     main:                Spec.hs
-#     source-dirs:         test
-#     ghc-options:
-#     - -threaded
-#     - -rtsopts
-#     - -with-rtsopts=-N
-#     dependencies:
-#     - servant-validate
+    - hspec
+    - should-not-typecheck

--- a/servant-validate.cabal
+++ b/servant-validate.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ebfad63ccb01b90eb3b27ce72fe45519b4f2039b00d5cbc3ce2a92e97a72fae7
+-- hash: ef0d21cd2b141bc442164590667f714ed2b7de5975d3dd705fe1912dac9ac424
 
 name:           servant-validate
 version:        0.1.0.0
@@ -40,17 +40,20 @@ library
     , text
   default-language: Haskell2010
 
-executable servant-validate-sample
-  main-is: servant-validate-sample.hs
+test-suite servant-validate-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
   other-modules:
       Paths_servant_validate
   hs-source-dirs:
-      app
+      test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , containers
+    , hspec
     , servant
     , servant-validate
+    , should-not-typecheck
     , text
   default-language: Haskell2010

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,10 @@
-
+{-# OPTIONS_GHC -fdefer-type-errors #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators    #-}
+
+import Test.Hspec (hspec, describe, it)
+import Test.ShouldNotTypecheck (shouldNotTypecheck)
 
 import           Data.Proxy
 import           Servant.API
@@ -19,5 +22,10 @@ testApi = Proxy
 validTestApi :: ValidApiTree TestApi
 validTestApi = validApiTree testApi
 
+
+
 main :: IO ()
-main = pure ()
+main = hspec $ do
+  describe "Servant" $ do
+    it "should not allow overlapping routes" $
+      shouldNotTypecheck validTestApi


### PR DESCRIPTION
having a sample executable makes it non-installable as a dependency - `should-not-typecheck` makes it testable.

(defaulted to hspec as a runner, not that important if you prefer something else.)