### PR TITLE
instance HasApiTree NoContentVerb

### DIFF
--- a/src/Servant/Validate.hs
+++ b/src/Servant/Validate.hs
@@ -107,6 +107,10 @@ instance (MethodString k, KnownSymbol (ToMethodString m)) => HasApiTree (Verb (m
     type ToApiTree (Verb m s t a) = 'Branch '[ToMethodString m] '[]
     sApiTree = SBranch (SSym :< PNil) PNil
 
+instance (MethodString k, KnownSymbol (ToMethodString m)) => HasApiTree (NoContentVerb (m :: k)) where
+    type ToApiTree (NoContentVerb m) = 'Branch '[ToMethodString m] '[]
+    sApiTree = SBranch (SSym :< PNil) PNil
+
 instance HasApiTree api => HasApiTree (Summary s :> api) where
     type ToApiTree (Summary s :> api) = ToApiTree api
     sApiTree = sApiTree @api

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/22.yaml
+resolver: lts-17.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,8 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532414
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/22.yaml
-    sha256: e483fb88549fc0f454c190979bf35ac91c7aceff2c0e71e7d8edd11842d772d8
-  original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/22.yaml
+    size: 565712
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/6.yaml
+    sha256: 4e5e581a709c88e3fe26a9ce8bf331435729bead762fb5c190064c6c5bb1b835
+  original: lts-17.6


### PR DESCRIPTION
This PR fixes an issue I encountered with Servant 0.18: http://hackage.haskell.org/package/servant-0.18.2/docs/Servant-API-Verbs.html#t:NoContentVerb

Tests appear to succeed:

```
servant-validate    > test (suite: servant-validate-test)
                                

Servant
  should not allow overlapping routes
  should not allow overlapping routes (nested)

Finished in 0.0004 seconds
2 examples, 0 failures

servant-validate    > Test suite servant-validate-test passed
```

Thanks